### PR TITLE
Fix integration workflow dispatch on tag

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,9 +13,6 @@ on:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"
 
-env:
-  BRANCH: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name) }}
-
 jobs:
   setup:
     name: Setup ${{ matrix.criteria.title }}
@@ -58,7 +55,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: upload.yaml
-          ref: ${{ env.BRANCH }}  # Workflow dispatch only works on branches or tags
+          ref: ${{ github.head_ref || github.ref_name }}  # Workflow dispatch only works on branches or tags
           inputs: |
             {
               "title": "${{ steps.workflow-run-title.outputs.name }}",


### PR DESCRIPTION
Previously the workflow dispatch on tag would fail as the ref would end up being `false`: https://github.com/beacon-biosignals/download-run-attempt-artifact/actions/runs/12915846912/job/36018653893