### PR TITLE
Shorten description

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,9 +1,7 @@
 ---
 name: Download Run Attempt Artifact
-description: >-
-  Downloads an artifact which was uploaded by workflow in the specified run attempt. This
-  action mirrors the `actions/download-artifact` but additionally supports downloading an
-  artifact from a specific `run-attempt`.
+description: >-  # Must be less than 125 characters
+  Downloads an artifact uploaded by a specific workflow run attempt.
 branding:
   color: purple
   icon: download


### PR DESCRIPTION
I am unable to publish the action to the GHA market place with a description longer than 125 characters.