### PR TITLE
Change Dependabot interval to kickstart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily


### PR DESCRIPTION
Seems like something was broken but I can't debug as the logs have expired: https://github.com/beacon-biosignals/download-run-attempt-artifact/actions/workflows/dependabot/dependabot-updates